### PR TITLE
fixed small issue: open current folder in vscode

### DIFF
--- a/prepare_java_project.ps1
+++ b/prepare_java_project.ps1
@@ -70,4 +70,4 @@ Write-Host "Congratulations! Your Java project folder is ready for VSCode!"
 Write-Host "Save the workspace before you start compiling or running tests."
 
 Set-Location -Path $fullPath
-code $fullPath
+code $fullPath .


### PR DESCRIPTION
Hi! Without the dot it simply opens vscode but not the current folder you're in. I